### PR TITLE
Allow warn to take kwargs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,7 @@ gemfile:
   - gemfiles/rails_5_0.gemfile
   - gemfiles/rails_5_1.gemfile
   - gemfiles/rails_5_2.gemfile
+
+branches:
+  only:
+  - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: ruby
+
+rvm:
+  - 2.4.2
+  - 2.6.1
+
+gemfile:
+  - gemfiles/rails_4_2.gemfile
+  - gemfiles/rails_5_0.gemfile
+  - gemfiles/rails_5_1.gemfile
+  - gemfiles/rails_5_2.gemfile

--- a/lib/uncruft/version.rb
+++ b/lib/uncruft/version.rb
@@ -1,3 +1,3 @@
 module Uncruft
-  VERSION = '0.0.1'.freeze
+  VERSION = '0.0.2'.freeze
 end

--- a/lib/uncruft/warning.rb
+++ b/lib/uncruft/warning.rb
@@ -2,7 +2,7 @@ module Uncruft
   module Warning
     DEPRECATION_PATTERN = /(deprecation|deprecated)/i
 
-    def warn(str)
+    def warn(str, *args)
       if str =~ DEPRECATION_PATTERN # rubocop:disable Performance/RegexpMatch
         message = strip_caller_info(str, caller_locations(1..1).first).strip
         ActiveSupport::Deprecation.warn(message)

--- a/spec/uncruft/warning_spec.rb
+++ b/spec/uncruft/warning_spec.rb
@@ -12,6 +12,11 @@ describe Uncruft::Warning do
     Warning.warn('oh no, you should worry')
   end
 
+  it "excepts kwargs from Kernel.warn" do
+    warn('oh no, you should worry', uplevel: 1)
+    Kernel.warn('oh no, you should worry', uplevel: 1)
+  end
+
   context 'when warning includes the word "deprecation" or "deprecated"' do
     it 'treats it as a deprecation warning' do
       expect(ActiveSupport::Deprecation).to receive(:warn).and_return('banana').exactly(6).times

--- a/spec/uncruft/warning_spec.rb
+++ b/spec/uncruft/warning_spec.rb
@@ -12,7 +12,7 @@ describe Uncruft::Warning do
     Warning.warn('oh no, you should worry')
   end
 
-  it "excepts kwargs from Kernel.warn" do
+  it "accepts kwargs from Kernel.warn" do
     warn('oh no, you should worry', uplevel: 1)
     Kernel.warn('oh no, you should worry', uplevel: 1)
   end


### PR DESCRIPTION
/domain @smudge 
/no-platform 

I ran across an issue when running on ruby 2.6.1. It looks like `Kernel.warn` [can take kwargs](https://docs.ruby-lang.org/en/2.6.0/Kernel.html#method-i-warn) (you can see [an example of it in use here](https://github.com/ruby/ruby/blob/v2_6_1/ext/bigdecimal/lib/bigdecimal.rb#L4)), but since uncruft expects only 1 arg, you end up with an exception.

I also threw in a travis config (fixes #1)