### PR TITLE
Update linked guide to reference main

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Then run `bundle install`.
 
 By default, deprecation warnings will cause your application to raise exceptions in `test` and `development` modes.
 
-The exception message will include the original deprecation warning, plus a link to [our troubleshooting guide](https://github.com/Betterment/uncruft/blob/master/GUIDE.md), to assist with resolving deprecations as they are encountered.
+The exception message will include the original deprecation warning, plus a link to [our troubleshooting guide](https://github.com/Betterment/uncruft/blob/main/GUIDE.md), to assist with resolving deprecations as they are encountered.
 
 ## Recording Deprecations
 

--- a/lib/uncruft/deprecation_handler.rb
+++ b/lib/uncruft/deprecation_handler.rb
@@ -86,7 +86,7 @@ module Uncruft
         To resolve this error, adjust your code according to the instructions above.
         If you did not introduce this error or are unsure why you are seeing it,
         you will find additional guidance at the URL below:
-        https://github.com/Betterment/uncruft/blob/master/GUIDE.md
+        https://github.com/Betterment/uncruft/blob/main/GUIDE.md
       ERROR
     end
 

--- a/spec/uncruft/deprecation_handler_spec.rb
+++ b/spec/uncruft/deprecation_handler_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Uncruft::DeprecationHandler do
         To resolve this error, adjust your code according to the instructions above.
         If you did not introduce this error or are unsure why you are seeing it,
         you will find additional guidance at the URL below:
-        https://github.com/Betterment/uncruft/blob/master/GUIDE.md
+        https://github.com/Betterment/uncruft/blob/main/GUIDE.md
       ERROR
     end
 


### PR DESCRIPTION
/platform @smudge

A very minor change, but when hitting a deprecation warning, I noticed that the `GUIDE.md` link still references the `master` branch instead of `main`. So, I've updated the reference in the error message, specs, and in the `README.md`.