### PR TITLE
Bump version to 0.2.1 and add a CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,51 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project aims to adhere to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added <!-- for new features. -->
+### Changed <!-- for changes in existing functionality. -->
+### Deprecated <!-- for soon-to-be removed features. -->
+### Removed <!-- for now removed features. -->
+### Fixed <!-- for any bug fixes. -->
+
+## [0.2.1] - 2021-09-03
+### Changed
+- Changes the default CI build branch to `main`, and updates links in GUIDE.md
+### Added
+- Adds a "heads up" message to the top of the GUIDE.md indicating that you
+  should check what version of the gem you are running before following the
+  instructions.
+
+## [0.2.0] - 2020-10-29
+### Added
+- This release adds a new `deprecate_attribute` helper! To get started, simply
+  include `Uncruft::Deprecatable` in your class, and then supply an attribute
+  name and deprecation message, like so: `deprecate_attribute :old_name,
+  message: "Please stop using old_name"`. Note that this will deprecate both
+  the getter and the setter. To apply this to just a single method, use
+  `deprecate_method`.
+- Special thanks to @yieldjessyield for the contribution!
+
+## [0.1.0] - 2020-01-21
+### Changed
+- This release updates variable names and documentation to use more inclusive
+  language. The ENV var for adding deprecations to the ignorefile is now
+  `RECORD_DEPRECATIONS=1`.
+
+## [0.0.2] - 2019-06-07
+### Fixed
+- Fixes an argument arity issue with `Kernal.warn` on newer rubies.
+
+## [0.0.1] - 2019-04-30
+### Added
+- Initial open source commit! This gem has been used internally at Betterment
+  for almost a year, and we've decided to open source it!
+
+[0.2.1]: https://github.com/betterment/uncruft/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/betterment/uncruft/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/betterment/uncruft/compare/v0.0.2...v0.1.0
+[0.0.2]: https://github.com/betterment/uncruft/compare/v0.0.1...v0.0.2
+[0.0.1]: https://github.com/betterment/uncruft/releases/tag/v0.0.1

--- a/lib/uncruft/version.rb
+++ b/lib/uncruft/version.rb
@@ -1,3 +1,3 @@
 module Uncruft
-  VERSION = '0.2.0'.freeze
+  VERSION = '0.2.1'.freeze
 end


### PR DESCRIPTION
/domain @yieldjessyield @pat-whitrock @alecclarke @effron @samandmoore 
/no-platform

Following on the heels of the [Betterment/delayed](https://github.com/Betterment/delayed) release, I decided to follow the same release pattern and add a CHANGELOG.md! This release also pulls in a change that links to the right GUIDE.md location (after the default branch was changed to `main`).