### PR TITLE
Remove deprecated ActiveSupport::Deprecation singleton

### DIFF
--- a/lib/uncruft.rb
+++ b/lib/uncruft.rb
@@ -2,6 +2,7 @@ require 'active_support'
 require 'active_support/time'
 
 require 'uncruft/version'
+require 'uncruft/deprecator'
 require 'uncruft/railtie'
 require 'uncruft/deprecation_handler'
 require 'uncruft/deprecatable'

--- a/lib/uncruft/deprecatable.rb
+++ b/lib/uncruft/deprecatable.rb
@@ -13,7 +13,7 @@ module Uncruft
 
         prepended_method.module_eval do
           define_method method do |*args, &block|
-            ActiveSupport::Deprecation.warn(message)
+            Uncruft.deprecator.warn(message)
             super(*args, &block)
           end
         end

--- a/lib/uncruft/deprecator.rb
+++ b/lib/uncruft/deprecator.rb
@@ -1,0 +1,5 @@
+module Uncruft
+  def self.deprecator
+    @deprecator ||= ActiveSupport::Deprecation.new(Uncruft::VERSION, "Uncruft")
+  end
+end

--- a/lib/uncruft/railtie.rb
+++ b/lib/uncruft/railtie.rb
@@ -9,6 +9,10 @@ module Uncruft
         strategies.unshift(DeprecationHandler.new)
         config.active_support.deprecation = strategies
       end
+
+      initializer "uncruft.deprecator" do |app|
+        app.deprecators[:uncruft] = Uncruft.deprecator
+      end
     end
   end
 end

--- a/lib/uncruft/warning.rb
+++ b/lib/uncruft/warning.rb
@@ -5,7 +5,7 @@ module Uncruft
     def warn(str, *args, **kwargs)
       if str =~ DEPRECATION_PATTERN # rubocop:disable Performance/RegexpMatch
         message = strip_caller_info(str, caller_locations(1..1).first).strip
-        ActiveSupport::Deprecation.warn(message)
+        Uncruft.deprecator.warn(message)
       elsif RUBY_VERSION < '2.7' && kwargs.empty?
         super(str, *args)
       else

--- a/spec/uncruft/deprecatable_spec.rb
+++ b/spec/uncruft/deprecatable_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Uncruft::Deprecatable do
     end
 
     it 'applies deprecation warning when setting deprecated attribute' do
-      expect(ActiveSupport::Deprecation).to receive(:warn).once
+      expect(Uncruft.deprecator).to receive(:warn).once
         .with("Please stop using this attribute!")
 
       expect(subject.first_name = my_name).to eq my_name
@@ -27,7 +27,7 @@ RSpec.describe Uncruft::Deprecatable do
     it 'applies deprecation warning when getting deprecated attribute' do
       subject.instance_variable_set(:@first_name, my_name)
 
-      expect(ActiveSupport::Deprecation).to receive(:warn)
+      expect(Uncruft.deprecator).to receive(:warn)
         .with("Please stop using this attribute!")
 
       expect(subject.first_name).to eq my_name
@@ -49,7 +49,7 @@ RSpec.describe Uncruft::Deprecatable do
     end
 
     it 'applies deprecation warning when calling the deprecated method' do
-      expect(ActiveSupport::Deprecation).to receive(:warn)
+      expect(Uncruft.deprecator).to receive(:warn)
         .with("Please stop using this method!")
 
       expect(subject.legacy_method).to eq "Hello Old World!"

--- a/spec/uncruft/warning_spec.rb
+++ b/spec/uncruft/warning_spec.rb
@@ -6,7 +6,7 @@ describe Uncruft::Warning do
   end
 
   it "doesn't block generic warnings" do
-    expect(ActiveSupport::Deprecation).not_to receive(:warn)
+    expect(Uncruft.deprecator).not_to receive(:warn)
     warn('oh no, you should worry')
     Kernel.warn('oh no, you should worry')
     Warning.warn('oh no, you should worry')
@@ -19,7 +19,7 @@ describe Uncruft::Warning do
 
   context 'when warning includes the word "deprecation" or "deprecated"' do
     it 'treats it as a deprecation warning' do
-      expect(ActiveSupport::Deprecation).to receive(:warn).and_return('banana').exactly(6).times
+      expect(Uncruft.deprecator).to receive(:warn).and_return('banana').exactly(6).times
       expect(warn('[dEpReCaTiOn] oh no, you should worry')).to eq 'banana'
       expect(Kernel.warn('[dEpReCaTiOn] oh no, you should worry')).to eq 'banana'
       expect(Warning.warn('[dEpReCaTiOn] oh no, you should worry')).to eq 'banana'
@@ -29,16 +29,16 @@ describe Uncruft::Warning do
     end
 
     context 'and when warning includes caller info' do
-      it 'strips out the path so that ActiveSupport::Deprecation can append a new one' do
+      it 'strips out the path so that Uncruft.deprecator can append a new one' do
         path = caller_locations(0..0).first.path
 
-        allow(ActiveSupport::Deprecation).to receive(:warn).with('foo is deprecated!').and_return('hurray')
+        allow(Uncruft.deprecator).to receive(:warn).with('foo is deprecated!').and_return('hurray')
         expect(warn("#{path}: foo is deprecated!")).to eq('hurray')
 
-        allow(ActiveSupport::Deprecation).to receive(:warn).with('[DEPRECATION] bar is no more.').and_return('huzzah')
+        allow(Uncruft.deprecator).to receive(:warn).with('[DEPRECATION] bar is no more.').and_return('huzzah')
         expect(Kernel.warn("[DEPRECATION] bar is no more. #{path}:#{caller_locations(0..0).first.lineno}")).to eq('huzzah')
 
-        allow(ActiveSupport::Deprecation).to receive(:warn).with('Deprecation detected: banana --').and_return('we do our best...')
+        allow(Uncruft.deprecator).to receive(:warn).with('Deprecation detected: banana --').and_return('we do our best...')
         expect(Warning.warn("Deprecation detected: banana -- #{caller(0..0).first}")).to eq('we do our best...')
       end
     end


### PR DESCRIPTION
Using `ActiveSupport::Deprecation` directly has itself been deprecated in favor of storing an instance of it in your own gem. 

I’ve given a try to fixing this in the simplest way possible as [described in the docs](https://api.rubyonrails.org/classes/ActiveSupport/Deprecation.html). I updated the existing tests (which are passing for me) but have not written new ones. (The only one I can think of is for the Railtie fix?) Hopefully I’m not missing any important points.