### PR TITLE
Handle gems installed with --user-install

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    uncruft (0.4.0)
+    uncruft (0.5.0)
       railties (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    uncruft (0.4.0)
+    uncruft (0.5.0)
       railties (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    uncruft (0.4.0)
+    uncruft (0.5.0)
       railties (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    uncruft (0.4.0)
+    uncruft (0.5.0)
       railties (>= 6.1.0)
 
 GEM

--- a/lib/uncruft/deprecation_handler.rb
+++ b/lib/uncruft/deprecation_handler.rb
@@ -44,6 +44,10 @@ module Uncruft
         message.gsub!(gem_home, '$GEM_PATH')
       end
 
+      if (user_install = user_install(message)).present?
+        message.gsub!(user_install, '$GEM_PATH')
+      end
+
       if message.include?(bin_dir)
         message.gsub!(bin_dir, '$BIN_PATH')
       end
@@ -70,7 +74,11 @@ module Uncruft
     end
 
     def gem_home(message)
-      message.match(%r{(?i:c)alled from( .+ at)? (#{ENV['GEM_HOME']}/(.+/)*gems)})&.[](2) # rubocop:disable Style/FetchEnvVar
+      message.match(%r{(?i:c)alled from( .+ at)? (#{ENV.fetch('GEM_HOME', nil)}/(.+/)*gems)})&.[](2).presence
+    end
+
+    def user_install(message)
+      message.match(%r{(?i:c)alled from( .+ at)? (#{Gem.user_dir}/(.+/)*gems)})&.[](2).presence
     end
 
     def absolute_path(message)

--- a/lib/uncruft/version.rb
+++ b/lib/uncruft/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Uncruft
-  VERSION = '0.4.0'
+  VERSION = '0.5.0'
 end


### PR DESCRIPTION
/no-platform

When you install gems with `--user-install`, they will go in `~/.gem` instead of in, e.g. `~/.rbenv` (or wherever your default GEM_PATH is).

This is a relatively uncommon way for gems to be installed, but it's technically supported by bundler & rubygems, and it causes issues with `uncruft`'s ability to resolve `$GEM_HOME` in ignorefile entries. This PR adds an additional check against `Gem.user_dir` and treats it as equivalent to `$GEM_HOME` (since the ignorefile is designed to work across multiple systems, and should not care where the gems are installed).