### PR TITLE
Add support for git-sourced gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    uncruft (0.6.2)
+    uncruft (0.7.0)
       railties (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    uncruft (0.6.2)
+    uncruft (0.7.0)
       railties (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    uncruft (0.6.2)
+    uncruft (0.7.0)
       railties (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    uncruft (0.6.2)
+    uncruft (0.7.0)
       railties (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    uncruft (0.6.2)
+    uncruft (0.7.0)
       railties (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    uncruft (0.6.2)
+    uncruft (0.7.0)
       railties (>= 6.1.0)
 
 GEM

--- a/lib/uncruft/deprecation_handler.rb
+++ b/lib/uncruft/deprecation_handler.rb
@@ -30,7 +30,7 @@ module Uncruft
     end
 
     def line_number(message)
-      message.match(/called from( .+ at)? .+:(\d+)/)&.[](2)
+      message[/called from( .+ at)? .+:(\d+)/, 2]
     end
 
     # Rails deprecation message formats found here:
@@ -71,11 +71,11 @@ module Uncruft
 
     def gem_path(message)
       paths = [ENV.fetch('GEM_HOME', nil), Bundler.home.to_s, Gem.user_dir].compact
-      message.match(%r{(?i:c)alled from( .+ at)? (#{Regexp.union(paths)}/(.+/)*gems)})&.[](2).presence
+      message[%r{(?i:c)alled from( .+ at)? (#{Regexp.union(paths)}/(.+/)*gems)}, 2].presence
     end
 
     def absolute_path(message)
-      message.match(/called from( .+ at)? (.+):\d/)&.[](2)
+      message[/called from( .+ at)? (.+):\d/, 2]
     end
 
     def relative_path(absolute_path)

--- a/lib/uncruft/deprecation_handler.rb
+++ b/lib/uncruft/deprecation_handler.rb
@@ -40,16 +40,8 @@ module Uncruft
     end
 
     def normalize_callstack_path(message)
-      if (gem_home = gem_home(message)).present?
-        message.gsub!(gem_home, '$GEM_PATH')
-      end
-
-      if (bundler_home = bundler_home(message)).present?
-        message.gsub!(bundler_home, '$GEM_PATH')
-      end
-
-      if (user_install = user_install(message)).present?
-        message.gsub!(user_install, '$GEM_PATH')
+      if (gem_path = gem_path(message)).present?
+        message.gsub!(gem_path, '$GEM_PATH')
       end
 
       if message.include?(bin_dir)
@@ -77,16 +69,9 @@ module Uncruft
       message.sub(/(called from( .+ at)? .+):\d+/, '\1')
     end
 
-    def gem_home(message)
-      message.match(%r{(?i:c)alled from( .+ at)? (#{ENV.fetch('GEM_HOME', nil)}/(.+/)*gems)})&.[](2).presence
-    end
-
-    def bundler_home(message)
-      message.match(%r{(?i:c)alled from( .+ at)? (#{Bundler.home}/(.+/)*gems)})&.[](2).presence
-    end
-
-    def user_install(message)
-      message.match(%r{(?i:c)alled from( .+ at)? (#{Gem.user_dir}/(.+/)*gems)})&.[](2).presence
+    def gem_path(message)
+      paths = [ENV.fetch('GEM_HOME', nil), Bundler.home.to_s, Gem.user_dir].compact
+      message.match(%r{(?i:c)alled from( .+ at)? (#{Regexp.union(paths)}/(.+/)*gems)})&.[](2).presence
     end
 
     def absolute_path(message)

--- a/lib/uncruft/deprecation_handler.rb
+++ b/lib/uncruft/deprecation_handler.rb
@@ -44,6 +44,10 @@ module Uncruft
         message.gsub!(gem_home, '$GEM_PATH')
       end
 
+      if (bundler_home = bundler_home(message)).present?
+        message.gsub!(bundler_home, '$GEM_PATH')
+      end
+
       if (user_install = user_install(message)).present?
         message.gsub!(user_install, '$GEM_PATH')
       end
@@ -75,6 +79,10 @@ module Uncruft
 
     def gem_home(message)
       message.match(%r{(?i:c)alled from( .+ at)? (#{ENV.fetch('GEM_HOME', nil)}/(.+/)*gems)})&.[](2).presence
+    end
+
+    def bundler_home(message)
+      message.match(%r{(?i:c)alled from( .+ at)? (#{Bundler.home}/(.+/)*gems)})&.[](2).presence
     end
 
     def user_install(message)

--- a/lib/uncruft/version.rb
+++ b/lib/uncruft/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Uncruft
-  VERSION = '0.6.2'
+  VERSION = '0.7.0'
 end

--- a/spec/uncruft/deprecation_handler_spec.rb
+++ b/spec/uncruft/deprecation_handler_spec.rb
@@ -118,6 +118,7 @@ RSpec.describe Uncruft::DeprecationHandler do
         allow(ENV).to receive(:fetch).and_call_original
         allow(ENV).to receive(:fetch).with('GEM_HOME', nil).and_return('/banana/banana/banana')
         allow(Gem).to receive(:user_dir).and_return('/apple/apple/apple')
+        allow(Bundler).to receive(:home).and_return('/cherry/cherry/cherry')
       end
 
       it 'sanitizes the message and raises an error' do
@@ -126,6 +127,14 @@ RSpec.describe Uncruft::DeprecationHandler do
 
       context 'when gem home is nested' do
         let(:absolute_path) { Pathname.new('/banana/banana/banana/arbitrary/gem/path/gems/chicken/nuggets.rb') }
+
+        it 'sanitizes the message and raises an error' do
+          expect { subject.call(message, '') }.to raise_error(RuntimeError, expected_error_message)
+        end
+      end
+
+      context 'when gem is installed in the Bundler.home path' do
+        let(:absolute_path) { Pathname.new('/cherry/cherry/cherry/ohno/gems/chicken/nuggets.rb') }
 
         it 'sanitizes the message and raises an error' do
           expect { subject.call(message, '') }.to raise_error(RuntimeError, expected_error_message)


### PR DESCRIPTION
Gems installed using Bundler's git support are not installed to `$GEM_HOME` or `Gem.user_dir`. They're installed to `Bundle.home`.

Here's an example:

```
$ bundle init
$ bundle add uncruft --git https://github.com/Betterment/uncruft
$ bundle show uncruft
/Users/rayzane/.rbenv/versions/3.2.3/lib/ruby/gems/3.2.0/bundler/gems/uncruft-ef90c54b656e
$ bundle exec ruby -e 'puts Bundler.home'
/Users/rayzane/.rbenv/versions/3.2.3/lib/ruby/gems/3.2.0/bundler
```

